### PR TITLE
fix: check if subscription exists before sending delivery message

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,8 @@
+# 0.2.1
+
+- Check subscription exists before sending the message to subscriber session.
+  This should avoid indefinite wait for PUBACK if message dispatched before subscription is inserted.
+
 # 0.2.0
 
 - Add retention based garbage collection for pending fanouts.
@@ -5,4 +10,4 @@
 
 # 0.1.0
 
-- Basic functionality
+- aBasic functionality

--- a/priv/config.hocon
+++ b/priv/config.hocon
@@ -10,8 +10,7 @@ gc_interval = "1h"
 
 # Topic prefix pattern for fanout data.
 # Must have placeholder '{VIN}'.
-# For example 'agent/{VIN}/proxy/request/'
+# For example 'agent/{VIN}/proxy/request'
 # means the vehicle will subscribe to 'agent/{VIN}/proxy/+'
 # and the fanout data will be published as 'agent/${VIN}/proxy/${REQ_ID}'
-# Note: end with `/` if request ID is meant to be a topic level
-topic_prefix = "agent/{VIN}/proxy/request/"
+topic_prefix = "agent/{VIN}/proxy/request"

--- a/priv/config_i18n.json
+++ b/priv/config_i18n.json
@@ -28,8 +28,7 @@
     "en": "Topic Prefix Template"
   },
   "$topic_prefix_desc": {
-    "zh": "扇出数据的主题前缀模版。必须包含占位符 '{VIN}'。例如 'agent/{VIN}/proxy/request/' 表示车辆将订阅 'agent/{VIN}/proxy/+'，扇出数据将发布到主题 'agent/${VIN}/proxy/${REQ_ID}'。注意：如果请求 ID 作为主题层级，则以 '/' 结尾。",
-    "en": "Topic prefix template for fanout data. Must have placeholder '{VIN}'. For example 'agent/{VIN}/proxy/request/' means the vehicle will subscribe to 'agent/{VIN}/proxy/+' and the fanout data will be published to topic 'agent/${VIN}/proxy/${REQ_ID}'. Note: end with '/' if request ID is meant to be a topic level."
+    "zh": "扇出数据的主题前缀模版。必须包含占位符 '{VIN}'。例如 'agent/{VIN}/proxy/request' 表示车辆将订阅 'agent/{VIN}/proxy/+'，扇出数据将发布到主题 'agent/{VIN}/proxy/{REQ_ID}'。",
+    "en": "Topic prefix template for fanout data. Must have placeholder '{VIN}'. For example 'agent/{VIN}/proxy/request/' means the vehicle will subscribe to 'agent/{VIN}/proxy/+' and the fanout data will be published to topic 'agent/{VIN}/proxy/{REQ_ID}'."
   }
 }
-

--- a/priv/config_schema.avsc
+++ b/priv/config_schema.avsc
@@ -41,7 +41,7 @@
     {
       "name": "topic_prefix",
       "type": "string",
-      "default": "agent/{VIN}/proxy/request/",
+      "default": "agent/{VIN}/proxy/request",
       "$ui": {
         "component": "input",
         "flex": 12,


### PR DESCRIPTION
this is to avoid race condition at the beginning of a session creation, if the vehicle session is created but subscribe is not sent/inserted yet, the sent 'delivery' message may get dropped by the vehicle session