### PR TITLE
fix: add a safety guard for dispatcher pool restart

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,8 @@
+# 0.4.6
+
+- Fix handling of a race condition after vehicle client reconnects.
+- Add a safety guard for dispatcher pool restart caused inflight table leak.
+
 # 0.4.5
 
 - Fix a UI style hint: for pool size config, it should be integer input.

--- a/src/fanout/emqx_sdv_fanout_dispatcher.erl
+++ b/src/fanout/emqx_sdv_fanout_dispatcher.erl
@@ -204,6 +204,9 @@ start_link(Pool, Id) ->
 
 init([Pool, Id]) ->
     true = gproc_pool:connect_worker(Pool, {Pool, Id}),
+    %% link to the inflight table owner process, so if the dispatcher is restarted,
+    %% the inflight table owner process will delete the inflight records inserted by this dispatcher
+    true = erlang:link(whereis(emqx_sdv_fanout_inflight)),
     {ok, #{pool => Pool, id => Id}}.
 
 handle_call(_Request, _From, State) ->

--- a/test/emqx_sdv_fanout_inflight_SUITE.erl
+++ b/test/emqx_sdv_fanout_inflight_SUITE.erl
@@ -1,0 +1,50 @@
+-module(emqx_sdv_fanout_inflight_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-compile(export_all).
+-compile(nowarn_export_all).
+
+all() ->
+    [
+        F
+     || {F, _} <- ?MODULE:module_info(exports),
+        is_test_function(F)
+    ].
+
+is_test_function(F) ->
+    case atom_to_list(F) of
+        "t_" ++ _ -> true;
+        _ -> false
+    end.
+
+init_per_suite(Config) ->
+    Config.
+
+end_per_suite(_Config) ->
+    ok.
+
+init_per_testcase(_Case, Config) ->
+    Config.
+
+end_per_testcase(_Case, _Config) ->
+    ok.
+
+t_no_leak(_Config) ->
+    {ok, _} = emqx_sdv_fanout_inflight:start_link(),
+    {Pid, MRef} = spawn_monitor(fun() ->
+        link(whereis(emqx_sdv_fanout_inflight)),
+        emqx_sdv_fanout_inflight:insert(self(), 1, self(), make_ref()),
+        ?assert(emqx_sdv_fanout_inflight:exists(self())),
+        exit(normal)
+    end),
+    receive
+        {'DOWN', MRef, process, Pid, Reason} ->
+            ?assertEqual(normal, Reason)
+    end,
+    %% Make a random synced call to ensure the EXIT message is processed
+    _ = gen_server:call(emqx_sdv_fanout_inflight, foobar, infinity),
+    ?assertNot(emqx_sdv_fanout_inflight:exists(self())),
+    ok = emqx_sdv_fanout_inflight:stop(),
+    ok.

--- a/test/emqx_sdv_fanout_inflight_SUITE.erl
+++ b/test/emqx_sdv_fanout_inflight_SUITE.erl
@@ -45,6 +45,6 @@ t_no_leak(_Config) ->
     end,
     %% Make a random synced call to ensure the EXIT message is processed
     _ = gen_server:call(emqx_sdv_fanout_inflight, foobar, infinity),
-    ?assertNot(emqx_sdv_fanout_inflight:exists(self())),
+    ?assertNot(emqx_sdv_fanout_inflight:exists(Pid)),
     ok = emqx_sdv_fanout_inflight:stop(),
     ok.


### PR DESCRIPTION
The plugin is not designed to support dispatcher pool reconfigure, but added this fix anyways as a safety guard to avoid inflight table leaking due to whatever reason caused pool worker crash/restart.